### PR TITLE
use version number in storage pointers

### DIFF
--- a/contracts/libraries/LibDiamond.sol
+++ b/contracts/libraries/LibDiamond.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 library LibDiamond {
-    bytes32 constant DIAMOND_STORAGE_POSITION = keccak256("diamond.standard.diamond.storage");
+    bytes32 constant DIAMOND_STORAGE_POSITION = keccak256("pop.v1.diamond.storage");
 
     struct FacetAddressAndPosition {
         address facetAddress;

--- a/contracts/libraries/LibPOPNFT.sol
+++ b/contracts/libraries/LibPOPNFT.sol
@@ -7,7 +7,7 @@ import "./LibStorage.sol";
 library LibPOPNFT {
     using Counters for Counters.Counter;
 
-    bytes32 constant POPNFT_STORAGE_POSITION = keccak256("pop.standard.popnft.storage");
+    bytes32 constant POPNFT_STORAGE_POSITION = keccak256("pop.v1.nft.core.storage");
 
     struct POPNFTStorage {
         // Token name and symbol (immutable)

--- a/contracts/libraries/LibPermissions.sol
+++ b/contracts/libraries/LibPermissions.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 library LibPermissions {
-    bytes32 constant STORAGE_POSITION = keccak256("permissions.storage");
+    bytes32 constant STORAGE_POSITION = keccak256("pop.v1.permissions.storage");
     
     uint8 constant EXPRESSION_PERMISSION = 1;
     uint8 constant ACKNOWLEDGEMENT_PERMISSION = 2;

--- a/contracts/libraries/LibStorage.sol
+++ b/contracts/libraries/LibStorage.sol
@@ -7,10 +7,10 @@ pragma solidity ^0.8.20;
 // therefore preventing different facets with different state variables from clashing storage locations.
 library LibStorage {
     // Storage namespace positions
-    bytes32 constant EXPRESSION_STORAGE_POSITION = keccak256("pop.standard.expression.storage");
-    bytes32 constant ACKNOWLEDGEMENT_STORAGE_POSITION = keccak256("pop.standard.acknowledgement.storage");
-    bytes32 constant NFT_METADATA_STORAGE_POSITION = keccak256("pop.standard.nft.metadata.storage");
-    bytes32 constant GAS_COST_STORAGE_POSITION = keccak256("pop.standard.gas.cost.storage");
+    bytes32 constant EXPRESSION_STORAGE_POSITION = keccak256("pop.v1.expression.storage");
+    bytes32 constant ACKNOWLEDGEMENT_STORAGE_POSITION = keccak256("pop.v1.acknowledgement.storage");
+    bytes32 constant NFT_METADATA_STORAGE_POSITION = keccak256("pop.v1.nft.metadata.storage");
+    bytes32 constant GAS_COST_STORAGE_POSITION = keccak256("pop.v1.gas.cost.storage");
 
     // Helper structs (no storage position needed)
     struct MediaContent {


### PR DESCRIPTION
use version numbers and reflect the projects structure in the naming of storage pointers